### PR TITLE
Add INSTALL.txt file

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,0 +1,4 @@
+Zum installieren der Haskell Plattform unter Debian führen Sie folgendes
+Kommando aus:
+
+> aptitude install haskell-platform


### PR DESCRIPTION
Die INSTALL.txt Datei enthält eine kurze Info, wie man die Haskell Plattform
unter Debian (und Ubuntu) Linux installiert.